### PR TITLE
FEATURE: Keep `meta[name=theme-color]` up to date

### DIFF
--- a/javascripts/discourse/initializers/dark-light-toggle-hamburger.js
+++ b/javascripts/discourse/initializers/dark-light-toggle-hamburger.js
@@ -21,6 +21,27 @@ function activeScheme() {
   }
 }
 
+function updateThemeColor(frames = 0) {
+  // The number is arbitrary (~1s) and in most cases the actual count ends up
+  // being either 0 or 3 (Safari)
+  if (frames >= 60) {
+    // The style is unlikely to load at this point so bail
+    return;
+  }
+
+  let color = getComputedStyle(document.documentElement).getPropertyValue(
+    "--header_background"
+  );
+
+  if (color) {
+    document
+      .querySelector("meta[name=theme-color]")
+      .setAttribute("content", color);
+  } else {
+    requestAnimationFrame(() => updateThemeColor(frames + 1));
+  }
+}
+
 export default {
   name: "dark-light-toggle-hamburger-initializer",
 
@@ -72,9 +93,12 @@ Have you selected two different themes for your dark/light schemes in user prefe
       } else {
         switchToLight();
       }
+
+      updateThemeColor();
     };
 
     let loadDarkOrLight = function () {
+      updateThemeColor();
       let savedSchemeChoice = cookie("userSelectedScheme");
 
       if (!savedSchemeChoice) {
@@ -102,6 +126,10 @@ Have you selected two different themes for your dark/light schemes in user prefe
     }
 
     loadDarkOrLight();
+
+    window
+      .matchMedia("(prefers-color-scheme: dark)")
+      .addEventListener("change", updateThemeColor);
 
     withPluginApi("0.8", (api) => {
       // this will reset the scheme choice to 'auto' whenever a user


### PR DESCRIPTION
Also, update theme color on OS color scheme changes.

(Notice the Safari updating its UI color)
https://user-images.githubusercontent.com/66961/125190153-e225ad80-e23b-11eb-92eb-62e0a784dc0e.mov