### PR TITLE
FIX: Case when user has disabled auto-switching

### DIFF
--- a/javascripts/discourse/initializers/color-scheme-toggler.js
+++ b/javascripts/discourse/initializers/color-scheme-toggler.js
@@ -5,17 +5,28 @@ import {
 } from "../lib/color-scheme-override";
 import { schedule } from "@ember/runloop";
 import { withPluginApi } from "discourse/lib/plugin-api";
+import { loadColorSchemeStylesheet } from "discourse/lib/color-scheme-picker";
+import { currentThemeId } from "discourse/lib/theme-selector";
 
 export default {
   name: "color-scheme-toggler",
 
   initialize(container) {
     if (!Session.currentProp("darkModeAvailable")) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        "No dark color scheme available, the discourse-color-scheme-toggle component has no effect."
-      );
-      return;
+      const siteSettings = container.lookup("site-settings:main");
+      if (siteSettings.default_dark_mode_color_scheme_id > 0) {
+        loadColorSchemeStylesheet(
+          siteSettings.default_dark_mode_color_scheme_id,
+          currentThemeId(),
+          true
+        );
+      } else {
+        // eslint-disable-next-line no-console
+        console.warn(
+          "No dark color scheme available, the discourse-color-scheme-toggle component has no effect."
+        );
+        return;
+      }
     }
 
     const keyValueStore = container.lookup("service:key-value-store");

--- a/javascripts/discourse/lib/color-scheme-override.js
+++ b/javascripts/discourse/lib/color-scheme-override.js
@@ -2,7 +2,9 @@ export const COLOR_SCHEME_OVERRIDE_KEY = "color_scheme_override";
 
 export function colorSchemeOverride(type) {
   const lightScheme = document.querySelector("link.light-scheme");
-  const darkScheme = document.querySelector("link.dark-scheme");
+  const darkScheme =
+    document.querySelector("link.dark-scheme") ||
+    document.querySelector("link#cs-preview-dark");
 
   if (!lightScheme && !darkScheme) {
     return;


### PR DESCRIPTION
When user has disabled auto-switching, the dark color scheme isn't loaded, so we need to load it manually (if site has a dark scheme configured).