### PR TITLE
FIX: Don't show button in both sidebar and header

### DIFF
--- a/javascripts/discourse/connectors/sidebar-footer-actions/toggler-button.js
+++ b/javascripts/discourse/connectors/sidebar-footer-actions/toggler-button.js
@@ -4,10 +4,10 @@ export default {
   setupComponent(_args, component) {
     component.showInSidebar = false;
 
-    if (!Session.currentProp("darkModeAvailable")) {
-      if (component.siteSettings.default_dark_mode_color_scheme_id > 0) {
-        component.showInSidebar = true;
-      }
+    if (
+      !Session.currentProp("darkModeAvailable") &&
+      component.siteSettings.default_dark_mode_color_scheme_id < 0
+    ) {
       return;
     }
 

--- a/test/acceptance/toggle-test.js
+++ b/test/acceptance/toggle-test.js
@@ -65,3 +65,37 @@ acceptance("Color Scheme Toggle - sidebar icon", function (needs) {
     assert.ok(visible(toggleButton), "button in footer");
   });
 });
+
+acceptance("Color Scheme Toggle - sidebar icon", function (needs) {
+  needs.pretender((server, helper) => {
+    server.get("/color-scheme-stylesheet/2.json", () => {
+      return helper.response({
+        color_scheme_id: 2,
+        new_href:
+          "/stylesheets/color_definitions_wcag-dark_2_52_a09af66a69bc639c6d63acd81d4c3cea2985282e.css",
+      });
+    });
+  });
+
+  needs.settings({
+    enable_sidebar: true,
+    enable_experimental_sidebar_hamburger: true,
+    default_dark_mode_color_scheme_id: 2,
+  });
+
+  needs.hooks.beforeEach(() => {
+    settings.add_color_scheme_toggle_to_header = false;
+  });
+
+  test("shows in sidebar if site has auto dark mode", async function (assert) {
+    await visit("/");
+
+    assert.ok(
+      !visible(".header-color-scheme-toggle"),
+      "button not present in header"
+    );
+
+    const toggleButton = ".sidebar-footer-wrapper .color-scheme-toggler";
+    assert.ok(visible(toggleButton), "button in footer");
+  });
+});


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/discourse/discourse-color-scheme-toggle/pull/25