### PR TITLE
FIX: Light logo was shown in some routes

### DIFF
--- a/javascripts/discourse/initializers/color-scheme-toggler.js
+++ b/javascripts/discourse/initializers/color-scheme-toggler.js
@@ -3,7 +3,7 @@ import {
   COLOR_SCHEME_OVERRIDE_KEY,
   colorSchemeOverride,
 } from "../lib/color-scheme-override";
-import { schedule } from "@ember/runloop";
+import { later, schedule } from "@ember/runloop";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { loadColorSchemeStylesheet } from "discourse/lib/color-scheme-picker";
 import { currentThemeId } from "discourse/lib/theme-selector";
@@ -47,8 +47,14 @@ export default {
 
     if (Session.currentProp("darkModeAvailable") && storedOverride) {
       schedule("afterRender", () => {
-        // delay needed for logo override
         colorSchemeOverride(storedOverride);
+
+        const logoDarkSrc = document.querySelector(".title picture source");
+        if (!logoDarkSrc) {
+          // in some cases the logo widget is not yet rendered
+          // so we try again after a short delay
+          later(() => colorSchemeOverride(storedOverride), 500);
+        }
       });
     }
 


### PR DESCRIPTION
When loading the `/tags` route, the logo element isn't always present on a fresh page load so the component can't switch the styles to use the dark mode logo. This is likely because widgets are rendered outside the Ember run loop, there's no easy way to fix this from the component, but we can add a workaround. 

This PR tries to applies the dark mode calculations a second time after 500ms if the dark logo isn't found in the DOM.