### PR TITLE
Replace deprecated addToHeaderIcons plugin API

### DIFF
--- a/javascripts/discourse/initializers/color-scheme-toggler.js
+++ b/javascripts/discourse/initializers/color-scheme-toggler.js
@@ -69,7 +69,7 @@ export default {
 
     if (settings.add_color_scheme_toggle_to_header) {
       withPluginApi("0.8", (api) => {
-        api.addToHeaderIcons("header-toggle-button");
+        api.headerIcons.add("header-toggle-button");
       });
     }
   },


### PR DESCRIPTION
This change replaces the deprecated `addToHeaderIcons` with `headerIcons.add` as recommended in Discourse's [Upcoming Header Changes](https://meta.discourse.org/t/upcoming-header-changes-preparing-themes-and-plugins/296544) documentation.



https://meta.discourse.org/t/upcoming-header-changes-preparing-themes-and-plugins/296544#twisted_rightwards_arrows-what-are-the-replacements-5